### PR TITLE
refactor: add GitHubUser type to replace inline author type

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -9,13 +9,19 @@ export interface GitHubContext {
 	};
 }
 
+/** GitHub user account types */
+export type GitHubUserType = "User" | "Bot" | "Organization";
+
+/** Represents a GitHub user (human, bot, or organization) */
+export interface GitHubUser {
+	login: string;
+	type: GitHubUserType;
+}
+
 export interface TriggerInfo {
 	isCommentEvent: boolean;
 	triggerText: string;
-	author: {
-		login: string;
-		type: string;
-	};
+	author: GitHubUser;
 	authorAssociation: string;
 	issueNumber: number;
 	issueTitle: string;
@@ -41,8 +47,8 @@ export function extractTriggerInfo(
 		? (comment?.body as string)
 		: (issue.body as string);
 	const author = isCommentEvent
-		? (comment?.user as { login: string; type: string })
-		: (issue.user as { login: string; type: string });
+		? (comment?.user as GitHubUser)
+		: (issue.user as GitHubUser);
 	const authorAssociation = isCommentEvent
 		? (comment?.author_association as string)
 		: (issue.author_association as string);


### PR DESCRIPTION
## Summary
Replace inline `{ login: string; type: string }` author type with a proper GitHubUser interface.

## Changes
- Add `GitHubUserType` union type (`User` | `Bot` | `Organization`)
- Add `GitHubUser` interface with `login` and `type` properties
- Update `TriggerInfo.author` to use the new type
- Update type casts in `extractTriggerInfo`

## Benefits
- Type safety for user type values
- Reusable type across the codebase
- Better documentation through interface name
- Prevents invalid user type strings

Addresses part of #10