### PR TITLE
deps: switch to @earendil-works/pi-coding-agent + regen lock with optional deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@actions/core": "^3.0.1",
 				"@actions/github": "^9.1.1",
-				"@mariozechner/pi-coding-agent": "^0.70.6",
+				"@earendil-works/pi-coding-agent": "^0.74.0",
 				"tsx": "^4.21.0"
 			},
 			"devDependencies": {
@@ -90,26 +90,6 @@
 			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
 			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
 			"license": "MIT"
-		},
-		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.90.0",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-			"integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
-			"license": "MIT",
-			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
-			},
-			"bin": {
-				"anthropic-ai-sdk": "bin/cli"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
@@ -1410,27 +1390,146 @@
 				}
 			}
 		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+			"integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
+				"@earendil-works/pi-ai": "^0.74.0",
+				"typebox": "^1.1.24"
+			},
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+			"integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
-				"tslib": "^2.4.0"
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-ai/node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+			"integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.74.0",
+				"@earendil-works/pi-ai": "^0.74.0",
+				"@earendil-works/pi-tui": "^0.74.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"jiti": "^2.7.0",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"uuid": "^14.0.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.5"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+			"integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -2233,31 +2332,31 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
-			"integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+			"integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@mariozechner/clipboard-darwin-arm64": "0.3.3",
-				"@mariozechner/clipboard-darwin-universal": "0.3.3",
-				"@mariozechner/clipboard-darwin-x64": "0.3.3",
-				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
-				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
-				"@mariozechner/clipboard-linux-x64-musl": "0.3.3",
-				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
-				"@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-arm64": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
-			"integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2271,9 +2370,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-universal": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
-			"integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2284,9 +2383,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-darwin-x64": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
-			"integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
 			"cpu": [
 				"x64"
 			],
@@ -2300,9 +2399,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
-			"integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2316,9 +2415,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
-			"integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2332,9 +2431,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
-			"integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2348,9 +2447,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
-			"integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
 			"cpu": [
 				"x64"
 			],
@@ -2364,9 +2463,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
-			"integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
 			"cpu": [
 				"x64"
 			],
@@ -2380,9 +2479,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
-			"integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2396,9 +2495,9 @@
 			}
 		},
 		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
-			"integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
 			"cpu": [
 				"x64"
 			],
@@ -2409,132 +2508,6 @@
 			],
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/jiti": {
-			"version": "2.6.5",
-			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-			"license": "MIT",
-			"dependencies": {
-				"std-env": "^3.10.0",
-				"yoctocolors": "^2.1.2"
-			},
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
-		"node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.70.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.6.tgz",
-			"integrity": "sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==",
-			"license": "MIT",
-			"dependencies": {
-				"@mariozechner/pi-ai": "^0.70.6",
-				"typebox": "^1.1.24"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@mariozechner/pi-ai": {
-			"version": "0.70.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.6.tgz",
-			"integrity": "sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@anthropic-ai/sdk": "^0.90.0",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"chalk": "^5.6.2",
-				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"proxy-agent": "^6.5.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"zod-to-json-schema": "^3.24.6"
-			},
-			"bin": {
-				"pi-ai": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@mariozechner/pi-ai/node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
-		},
-		"node_modules/@mariozechner/pi-coding-agent": {
-			"version": "0.70.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.6.tgz",
-			"integrity": "sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@mariozechner/jiti": "^2.6.2",
-				"@mariozechner/pi-agent-core": "^0.70.6",
-				"@mariozechner/pi-ai": "^0.70.6",
-				"@mariozechner/pi-tui": "^0.70.6",
-				"@silvia-odwyer/photon-node": "^0.3.4",
-				"chalk": "^5.5.0",
-				"cli-highlight": "^2.1.11",
-				"diff": "^8.0.2",
-				"extract-zip": "^2.0.1",
-				"file-type": "^21.1.1",
-				"glob": "^13.0.1",
-				"hosted-git-info": "^9.0.2",
-				"ignore": "^7.0.5",
-				"marked": "^15.0.12",
-				"minimatch": "^10.2.3",
-				"proper-lockfile": "^4.1.2",
-				"strip-ansi": "^7.1.0",
-				"typebox": "^1.1.24",
-				"undici": "^7.19.1",
-				"uuid": "^14.0.0",
-				"yaml": "^2.8.2"
-			},
-			"bin": {
-				"pi": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=20.6.0"
-			},
-			"optionalDependencies": {
-				"@mariozechner/clipboard": "^0.3.3"
-			}
-		},
-		"node_modules/@mariozechner/pi-coding-agent/node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
-		},
-		"node_modules/@mariozechner/pi-tui": {
-			"version": "0.70.6",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.6.tgz",
-			"integrity": "sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mime-types": "^2.1.4",
-				"chalk": "^5.5.0",
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12",
-				"mime-types": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"optionalDependencies": {
-				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
@@ -2593,6 +2566,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -3808,6 +3782,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
 			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.19.0"
 			}
@@ -4651,6 +4626,7 @@
 			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -6997,6 +6973,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7484,12 +7461,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"license": "MIT"
-		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -7701,6 +7672,7 @@
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -7764,6 +7736,7 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7842,6 +7815,7 @@
 			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -7920,6 +7894,7 @@
 			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.5",
 				"@vitest/mocker": "4.1.5",
@@ -8204,23 +8179,12 @@
 				"fd-slicer": "~1.1.0"
 			}
 		},
-		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/zod": {
 			"version": "4.3.6",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,26 @@
 			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
 			"license": "MIT"
 		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -231,28 +251,28 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1038.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1038.0.tgz",
-			"integrity": "sha512-oGiqs9v9WzPOdv7PDdm9iPibHgrbDvCDyNg43wFZn2PiiEUisFM+xUP2CRMsj41SmwZPhohmZkXiUu1+MghbAQ==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+			"integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/credential-provider-node": "^3.972.37",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/credential-provider-node": "^3.972.39",
 				"@aws-sdk/eventstream-handler-node": "^3.972.14",
 				"@aws-sdk/middleware-eventstream": "^3.972.10",
 				"@aws-sdk/middleware-host-header": "^3.972.10",
 				"@aws-sdk/middleware-logger": "^3.972.10",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/middleware-websocket": "^3.972.16",
 				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/token-providers": "3.1038.0",
+				"@aws-sdk/token-providers": "3.1045.0",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.22",
+				"@aws-sdk/util-user-agent-node": "^3.973.24",
 				"@smithy/config-resolver": "^4.4.17",
 				"@smithy/core": "^3.23.17",
 				"@smithy/eventstream-serde-browser": "^4.2.14",
@@ -263,7 +283,7 @@
 				"@smithy/invalid-dependency": "^4.2.14",
 				"@smithy/middleware-content-length": "^4.2.14",
 				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.6",
+				"@smithy/middleware-retry": "^4.5.7",
 				"@smithy/middleware-serde": "^4.2.20",
 				"@smithy/middleware-stack": "^4.2.14",
 				"@smithy/node-config-provider": "^4.3.14",
@@ -279,7 +299,7 @@
 				"@smithy/util-defaults-mode-node": "^4.2.54",
 				"@smithy/util-endpoints": "^3.4.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-stream": "^4.5.25",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
@@ -289,13 +309,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
-			"integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+			"version": "3.974.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+			"integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.20",
+				"@aws-sdk/xml-builder": "^3.972.22",
 				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -305,7 +325,7 @@
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -314,12 +334,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
-			"integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+			"integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/types": "^4.14.1",
@@ -330,12 +350,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
-			"integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+			"integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/fetch-http-handler": "^5.3.17",
 				"@smithy/node-http-handler": "^4.6.1",
@@ -351,19 +371,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
-			"integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+			"integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/credential-provider-env": "^3.972.32",
-				"@aws-sdk/credential-provider-http": "^3.972.34",
-				"@aws-sdk/credential-provider-login": "^3.972.36",
-				"@aws-sdk/credential-provider-process": "^3.972.32",
-				"@aws-sdk/credential-provider-sso": "^3.972.36",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.36",
-				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/credential-provider-env": "^3.972.34",
+				"@aws-sdk/credential-provider-http": "^3.972.36",
+				"@aws-sdk/credential-provider-login": "^3.972.38",
+				"@aws-sdk/credential-provider-process": "^3.972.34",
+				"@aws-sdk/credential-provider-sso": "^3.972.38",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -376,13 +396,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
-			"integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+			"integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
@@ -395,17 +415,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
-			"integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+			"integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.32",
-				"@aws-sdk/credential-provider-http": "^3.972.34",
-				"@aws-sdk/credential-provider-ini": "^3.972.36",
-				"@aws-sdk/credential-provider-process": "^3.972.32",
-				"@aws-sdk/credential-provider-sso": "^3.972.36",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.36",
+				"@aws-sdk/credential-provider-env": "^3.972.34",
+				"@aws-sdk/credential-provider-http": "^3.972.36",
+				"@aws-sdk/credential-provider-ini": "^3.972.38",
+				"@aws-sdk/credential-provider-process": "^3.972.34",
+				"@aws-sdk/credential-provider-sso": "^3.972.38",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -418,12 +438,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
-			"integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+			"integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -435,14 +455,32 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
-			"integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+			"integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/nested-clients": "^3.997.4",
-				"@aws-sdk/token-providers": "3.1038.0",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
+				"@aws-sdk/token-providers": "3.1041.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1041.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+			"integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -454,13 +492,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
-			"integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+			"integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -547,12 +585,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
-			"integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+			"integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-arn-parser": "^3.972.3",
 				"@smithy/core": "^3.23.17",
@@ -572,18 +610,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
-			"integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+			"integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@smithy/core": "^3.23.17",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-retry": "^4.3.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -614,24 +652,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.4",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
-			"integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+			"version": "3.997.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+			"integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/middleware-host-header": "^3.972.10",
 				"@aws-sdk/middleware-logger": "^3.972.10",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.23",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.25",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.22",
+				"@aws-sdk/util-user-agent-node": "^3.973.24",
 				"@smithy/config-resolver": "^4.4.17",
 				"@smithy/core": "^3.23.17",
 				"@smithy/fetch-http-handler": "^5.3.17",
@@ -639,7 +677,7 @@
 				"@smithy/invalid-dependency": "^4.2.14",
 				"@smithy/middleware-content-length": "^4.2.14",
 				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.6",
+				"@smithy/middleware-retry": "^4.5.7",
 				"@smithy/middleware-serde": "^4.2.20",
 				"@smithy/middleware-stack": "^4.2.14",
 				"@smithy/node-config-provider": "^4.3.14",
@@ -655,7 +693,7 @@
 				"@smithy/util-defaults-mode-node": "^4.2.54",
 				"@smithy/util-endpoints": "^3.4.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -680,12 +718,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
-			"integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+			"version": "3.996.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+			"integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.35",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.37",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
@@ -697,13 +735,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1038.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
-			"integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+			"integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.6",
-				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -795,12 +833,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
-			"integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
+			"version": "3.973.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+			"integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/types": "^4.14.1",
@@ -820,9 +858,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.21",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
-			"integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@nodable/entities": "2.1.0",
@@ -886,9 +924,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -935,9 +973,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
-			"integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.14.tgz",
+			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -951,20 +989,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.13",
-				"@biomejs/cli-darwin-x64": "2.4.13",
-				"@biomejs/cli-linux-arm64": "2.4.13",
-				"@biomejs/cli-linux-arm64-musl": "2.4.13",
-				"@biomejs/cli-linux-x64": "2.4.13",
-				"@biomejs/cli-linux-x64-musl": "2.4.13",
-				"@biomejs/cli-win32-arm64": "2.4.13",
-				"@biomejs/cli-win32-x64": "2.4.13"
+				"@biomejs/cli-darwin-arm64": "2.4.14",
+				"@biomejs/cli-darwin-x64": "2.4.14",
+				"@biomejs/cli-linux-arm64": "2.4.14",
+				"@biomejs/cli-linux-arm64-musl": "2.4.14",
+				"@biomejs/cli-linux-x64": "2.4.14",
+				"@biomejs/cli-linux-x64-musl": "2.4.14",
+				"@biomejs/cli-win32-arm64": "2.4.14",
+				"@biomejs/cli-win32-x64": "2.4.14"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
-			"integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.14.tgz",
+			"integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -979,9 +1017,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
-			"integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.14.tgz",
+			"integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -996,9 +1034,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
-			"integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.14.tgz",
+			"integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1013,9 +1051,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
-			"integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.14.tgz",
+			"integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1030,9 +1068,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
-			"integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.14.tgz",
+			"integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
 			"cpu": [
 				"x64"
 			],
@@ -1047,9 +1085,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
-			"integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.14.tgz",
+			"integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
 			"cpu": [
 				"x64"
 			],
@@ -1064,9 +1102,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
-			"integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.14.tgz",
+			"integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1081,9 +1119,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.13",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
-			"integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.14.tgz",
+			"integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
 			"cpu": [
 				"x64"
 			],
@@ -1098,9 +1136,9 @@
 			}
 		},
 		"node_modules/@borewit/text-codec": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-			"integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -1108,15 +1146,15 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "20.5.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.2.tgz",
-			"integrity": "sha512-IXr5xd3IX8SEG936P8gcpozRplkDeDSwJlt8UvoY1winwIy2udTbQ/cOCgbaaxcjdDqVoS29VUcz/wkwnSozbA==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
+			"integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/format": "^20.5.0",
-				"@commitlint/lint": "^20.5.0",
-				"@commitlint/load": "^20.5.2",
+				"@commitlint/lint": "^20.5.3",
+				"@commitlint/load": "^20.5.3",
 				"@commitlint/read": "^20.5.0",
 				"@commitlint/types": "^20.5.0",
 				"tinyexec": "^1.0.0",
@@ -1130,9 +1168,9 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
-			"integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
+			"integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1158,18 +1196,14 @@
 			}
 		},
 		"node_modules/@commitlint/ensure": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
-			"integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
+			"integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/types": "^20.5.0",
-				"lodash.camelcase": "^4.3.0",
-				"lodash.kebabcase": "^4.1.1",
-				"lodash.snakecase": "^4.1.1",
-				"lodash.startcase": "^4.4.0",
-				"lodash.upperfirst": "^4.3.1"
+				"es-toolkit": "^1.46.0"
 			},
 			"engines": {
 				"node": ">=v18"
@@ -1214,15 +1248,15 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
-			"integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
+			"integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/is-ignored": "^20.5.0",
 				"@commitlint/parse": "^20.5.0",
-				"@commitlint/rules": "^20.5.0",
+				"@commitlint/rules": "^20.5.3",
 				"@commitlint/types": "^20.5.0"
 			},
 			"engines": {
@@ -1230,20 +1264,20 @@
 			}
 		},
 		"node_modules/@commitlint/load": {
-			"version": "20.5.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.2.tgz",
-			"integrity": "sha512-zmr0RGDz7vThxW1I8ohb9yBjnGuH9mqwJpn21hInjGla+IlLOkS9ey0+dD5HlkzFlY0lX2NYdA2lDW6/0rO7Gw==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
+			"integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/config-validator": "^20.5.0",
 				"@commitlint/execute-rule": "^20.0.0",
-				"@commitlint/resolve-extends": "^20.5.2",
+				"@commitlint/resolve-extends": "^20.5.3",
 				"@commitlint/types": "^20.5.0",
 				"cosmiconfig": "^9.0.1",
 				"cosmiconfig-typescript-loader": "^6.1.0",
+				"es-toolkit": "^1.46.0",
 				"is-plain-obj": "^4.1.0",
-				"lodash.mergewith": "^4.6.2",
 				"picocolors": "^1.1.1"
 			},
 			"engines": {
@@ -1293,17 +1327,17 @@
 			}
 		},
 		"node_modules/@commitlint/resolve-extends": {
-			"version": "20.5.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.2.tgz",
-			"integrity": "sha512-8EhSCU9eNos/5cI1yg64GW79UH1c64O69AfStCsj4zqy6An/qIphVEXj4/+2M6056T8coz00f+UXFn4WUUP1HQ==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
+			"integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commitlint/config-validator": "^20.5.0",
 				"@commitlint/types": "^20.5.0",
+				"es-toolkit": "^1.46.0",
 				"global-directory": "^5.0.0",
 				"import-meta-resolve": "^4.0.0",
-				"lodash.mergewith": "^4.6.2",
 				"resolve-from": "^5.0.0"
 			},
 			"engines": {
@@ -1311,13 +1345,13 @@
 			}
 		},
 		"node_modules/@commitlint/rules": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
-			"integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
+			"integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/ensure": "^20.5.0",
+				"@commitlint/ensure": "^20.5.3",
 				"@commitlint/message": "^20.4.3",
 				"@commitlint/to-lines": "^20.0.0",
 				"@commitlint/types": "^20.5.0"
@@ -1428,26 +1462,6 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
-			"version": "0.91.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-			"license": "MIT",
-			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
-			},
-			"bin": {
-				"anthropic-ai-sdk": "bin/cli"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@earendil-works/pi-ai/node_modules/undici": {
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -1495,15 +1509,6 @@
 				"@mariozechner/clipboard": "^0.3.5"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
 			"version": "7.25.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -1530,6 +1535,31 @@
 			},
 			"optionalDependencies": {
 				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -1960,9 +1990,10 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.50.1",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
-			"integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"google-auth-library": "^10.3.0",
@@ -1983,9 +2014,9 @@
 			}
 		},
 		"node_modules/@j178/prek": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.3.11.tgz",
-			"integrity": "sha512-HGjXIKnbjuvXGzZ/Z0oNGbgXx3GBrmWiuVASxey4IY/qkMTd348dfi3CO1v/F0a+s2DH6/zIBozLmwbDFxwjFA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.3.13.tgz",
+			"integrity": "sha512-z5YMyNvyQK0Cfw8ljm/zJu/JswmCQ20e9iVtP18I8iwK7gMUawPYMffTiaGsH6y0p30GNPPstjdkN5STIleQ6Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1995,29 +2026,29 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@j178/prek-android-arm64": "0.3.11",
-				"@j178/prek-darwin-arm64": "0.3.11",
-				"@j178/prek-darwin-x64": "0.3.11",
-				"@j178/prek-linux-arm-gnueabihf": "0.3.11",
-				"@j178/prek-linux-arm-musleabihf": "0.3.11",
-				"@j178/prek-linux-arm64-gnu": "0.3.11",
-				"@j178/prek-linux-arm64-musl": "0.3.11",
-				"@j178/prek-linux-armv7-musleabihf": "0.3.11",
-				"@j178/prek-linux-ia32-gnu": "0.3.11",
-				"@j178/prek-linux-ia32-musl": "0.3.11",
-				"@j178/prek-linux-riscv64-gnu": "0.3.11",
-				"@j178/prek-linux-s390x-gnu": "0.3.11",
-				"@j178/prek-linux-x64-gnu": "0.3.11",
-				"@j178/prek-linux-x64-musl": "0.3.11",
-				"@j178/prek-win32-arm64-msvc": "0.3.11",
-				"@j178/prek-win32-ia32-msvc": "0.3.11",
-				"@j178/prek-win32-x64-msvc": "0.3.11"
+				"@j178/prek-android-arm64": "0.3.13",
+				"@j178/prek-darwin-arm64": "0.3.13",
+				"@j178/prek-darwin-x64": "0.3.13",
+				"@j178/prek-linux-arm-gnueabihf": "0.3.13",
+				"@j178/prek-linux-arm-musleabihf": "0.3.13",
+				"@j178/prek-linux-arm64-gnu": "0.3.13",
+				"@j178/prek-linux-arm64-musl": "0.3.13",
+				"@j178/prek-linux-armv7-musleabihf": "0.3.13",
+				"@j178/prek-linux-ia32-gnu": "0.3.13",
+				"@j178/prek-linux-ia32-musl": "0.3.13",
+				"@j178/prek-linux-riscv64-gnu": "0.3.13",
+				"@j178/prek-linux-s390x-gnu": "0.3.13",
+				"@j178/prek-linux-x64-gnu": "0.3.13",
+				"@j178/prek-linux-x64-musl": "0.3.13",
+				"@j178/prek-win32-arm64-msvc": "0.3.13",
+				"@j178/prek-win32-ia32-msvc": "0.3.13",
+				"@j178/prek-win32-x64-msvc": "0.3.13"
 			}
 		},
 		"node_modules/@j178/prek-android-arm64": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-android-arm64/-/prek-android-arm64-0.3.11.tgz",
-			"integrity": "sha512-70c6b4g5/LKKYk0fFD2jU0i9cg8akglY2kY2c7vhJi50WbS8DP+yzlEZU+yyWInJRec6UKWjR1SUdlVm62WkRQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-android-arm64/-/prek-android-arm64-0.3.13.tgz",
+			"integrity": "sha512-VBr2kIOAY0QpEuk0CrIBaiU8at/Xw5f47ga7Zrpcxzaz2KdJIYeWmbWsiIeNFv6Ko7y4xxY7Ho+EkZd3Pr/5DA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2032,9 +2063,9 @@
 			}
 		},
 		"node_modules/@j178/prek-darwin-arm64": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-darwin-arm64/-/prek-darwin-arm64-0.3.11.tgz",
-			"integrity": "sha512-3+1+gaRnXO8rWYYDseGpqUI14E81PbtavXlM38Q9FGyWnLBO1SJa/3P+Horm7HHUTxxqLXC4BJN46i+ZrWiZGg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-darwin-arm64/-/prek-darwin-arm64-0.3.13.tgz",
+			"integrity": "sha512-AsuXqvZ/WvV8McGnxMIyU7UeZo7e/BdkkzXAqSGjNM2ZnEW8difbr5H87sgE8YGrzxGsXkujEdkMbAotYgwoiQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2049,9 +2080,9 @@
 			}
 		},
 		"node_modules/@j178/prek-darwin-x64": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-darwin-x64/-/prek-darwin-x64-0.3.11.tgz",
-			"integrity": "sha512-D5zgmCloI3J7rHVAbKYAKY4MgXlHYjItRHAIQLTzreGRaNneyeUn6XMru8lL+WJjJvZuq6dICkMovS8YOWVZfw==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-darwin-x64/-/prek-darwin-x64-0.3.13.tgz",
+			"integrity": "sha512-CSEI4JDx/+9JECV6gzcHvi6wAFNbsPXZVuEvMaCiuPxc1ajTvmsgxTf5xCdXP3AmMErN6NeUkV0uqgqMFUjVSw==",
 			"cpu": [
 				"x64"
 			],
@@ -2066,9 +2097,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-arm-gnueabihf": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-gnueabihf/-/prek-linux-arm-gnueabihf-0.3.11.tgz",
-			"integrity": "sha512-PHEcTuZmFBNH/nL+Rnhj4ruGnWGH+EESTylSENBE+/eSt3mTu2SOHMVIcgH2cjflY4kQ3dPrQQiZO4TV7RBeRA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-gnueabihf/-/prek-linux-arm-gnueabihf-0.3.13.tgz",
+			"integrity": "sha512-dQt1onTfbjta+PpUrg0mmKHj60iMUSo/I35t+HFjImV26Ersml6H2Ww9NHJui2Z/bJ6i5MTYXAFWTq2YYtvlYA==",
 			"cpu": [
 				"arm"
 			],
@@ -2083,9 +2114,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-arm-musleabihf": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-musleabihf/-/prek-linux-arm-musleabihf-0.3.11.tgz",
-			"integrity": "sha512-I+sGvyNpuLVppLcdb0dcqnzcFfwgHanMRQ/eXyElBSKQKj9EG8tDtRXxiSK4Kk2ABs4VWAQxjPW4T+MWcHlcng==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-musleabihf/-/prek-linux-arm-musleabihf-0.3.13.tgz",
+			"integrity": "sha512-iTC580zeHNALrhpIZoesl2ksMozuTV6xiwhBOlnsIpQwKVijcExIZtPnG0zxYAbNfXFgt9mUKatrxsc0aHZmhQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2100,9 +2131,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-arm64-gnu": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-gnu/-/prek-linux-arm64-gnu-0.3.11.tgz",
-			"integrity": "sha512-q8nXpvz6e31UMmi0KRmDdQaQn+5ayeBU5xGv0+cXLREYYkJrnuHsehKuU1+IYL70bA43HDe8nkZykGrMEcvNFQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-gnu/-/prek-linux-arm64-gnu-0.3.13.tgz",
+			"integrity": "sha512-ZKa/FfMzQgni1KdSl5hOcaaYa9OvoOqB9DQo0dRSR6nuTIVsi8/G/ZuCl7Jnjel8vZB3LbOp7i2ZS//jDCnvUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2117,9 +2148,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-arm64-musl": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-musl/-/prek-linux-arm64-musl-0.3.11.tgz",
-			"integrity": "sha512-k+FVgpx9dbopRCRQ331GgClfk1mfxTG/JZ5nDKtilhFnZOFv7dhqlRBYb3kFGtq9RjyqSm1V4lRBG+o7FSjioQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-musl/-/prek-linux-arm64-musl-0.3.13.tgz",
+			"integrity": "sha512-XdgJCz0wPRR+NoZ1c50v7kVxQoPC2OopPCab32Mr4oFuAddqZZKjUL8k7nJUSHXR61i6fPxQKx8gS44vNRNSuA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2134,9 +2165,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-armv7-musleabihf": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-armv7-musleabihf/-/prek-linux-armv7-musleabihf-0.3.11.tgz",
-			"integrity": "sha512-lNZPkG4zdzP60PAGPK6sax9ReWiTyTh0bFkLK2P2jqTjcASL2j/t+YUiQ0omcKZLiGjDZNgvPLcifqA5EyKlcA==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-armv7-musleabihf/-/prek-linux-armv7-musleabihf-0.3.13.tgz",
+			"integrity": "sha512-pt+sUUJPsSSIiWHHSluUZ8sVUogro+m9e+9BBzGMDHggpSlHmfaYbTY0WjUDhSCFOS7G+NdF2sENdGpbAqYAdw==",
 			"cpu": [
 				"arm"
 			],
@@ -2151,9 +2182,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-ia32-gnu": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-gnu/-/prek-linux-ia32-gnu-0.3.11.tgz",
-			"integrity": "sha512-f/lZyp85jV7i/wzZSsOIMGbbwPvBN4OXQQd5HnX9F478O2OpbQZ/AkCbgTfM0edFSoA+9iyDqplj6vSQPXdHNQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-gnu/-/prek-linux-ia32-gnu-0.3.13.tgz",
+			"integrity": "sha512-hfjLDcK19FaqZ8IzVWOWFlfzV73wEw00RNgBOC7fJqJW7ckrSzx9CiIcMIrJ1/h0dprGR+iwmBLx7z5a1VDa+Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -2168,9 +2199,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-ia32-musl": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-musl/-/prek-linux-ia32-musl-0.3.11.tgz",
-			"integrity": "sha512-W5yWFoS5Bag3jxCwhFs1INc6vHaTXxFZAk+V9EhFlksfkC21iCKyOIO5X276ZR9qVtJUkqZKrwfxyobDIFNXIQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-musl/-/prek-linux-ia32-musl-0.3.13.tgz",
+			"integrity": "sha512-tCeSRH6rQHgyWtYnlY2RL+DPmCHEjCA9J8TEeOGUfigfuXlPeduqNYCbihfcmUURFASl6AR7g9jOF0mRZyPiHA==",
 			"cpu": [
 				"ia32"
 			],
@@ -2185,9 +2216,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-riscv64-gnu": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-riscv64-gnu/-/prek-linux-riscv64-gnu-0.3.11.tgz",
-			"integrity": "sha512-pcepsxYrtKtKlIgH5J6XGbBHPnGdQnBHFqND7tVrNbKoxRzrcmORRA42SLG4TfIUccPgBgojsE/JbMeYdiqxJg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-riscv64-gnu/-/prek-linux-riscv64-gnu-0.3.13.tgz",
+			"integrity": "sha512-RZvnILVk/iP7e89nBrSP4SLbyllGSMOUpFd5/fdo/FU3mN348umlIlTHVyXJ6Need2uOAJNgQQXZ0EdKnzpLEA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2202,9 +2233,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-s390x-gnu": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-s390x-gnu/-/prek-linux-s390x-gnu-0.3.11.tgz",
-			"integrity": "sha512-n6u9kK9D9NvV5G1ZIDCWj8gPnifsTot8hlDTn1uwWt1R6SkWa/s4FUTJ7tYn6/h9gEATKDYoElF1CBaHrmA6Pw==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-s390x-gnu/-/prek-linux-s390x-gnu-0.3.13.tgz",
+			"integrity": "sha512-sAhwUYU2Urfp5HnYhS/iYQ2XHsnJKnAOmuilTlw8jB6Y6zNOpmCNMsgSlPvP6fTN1ntsVarh6LwvuerajWs5Rw==",
 			"cpu": [
 				"s390x"
 			],
@@ -2219,9 +2250,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-x64-gnu": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-gnu/-/prek-linux-x64-gnu-0.3.11.tgz",
-			"integrity": "sha512-y59tjFAsmR8bYLYKVfOV8zFdvvsS4nEEODa/xeAhqOmtim60Ay5iR5JTKJRZ9CpEv2HuHKzwa50Wtti1sBb1Xg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-gnu/-/prek-linux-x64-gnu-0.3.13.tgz",
+			"integrity": "sha512-kyBOHaRqnuzF4KrWGxkFkZ/RkwxV6Yyf3DaBU9lgXMBKRs63MwLZRIE6EMKc6JQarEDYcFY5kGe1MNz5q9sflg==",
 			"cpu": [
 				"x64"
 			],
@@ -2236,9 +2267,9 @@
 			}
 		},
 		"node_modules/@j178/prek-linux-x64-musl": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-musl/-/prek-linux-x64-musl-0.3.11.tgz",
-			"integrity": "sha512-b3RDD2qLcCWu3rBSV7u8U1xWKRGm1VUX4n0RSiHv6lIkNnRazKoHHybR85So35TmdbX/Tuzg7FsO/X6A+Glc2w==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-musl/-/prek-linux-x64-musl-0.3.13.tgz",
+			"integrity": "sha512-Wo3ogs/OaFD9izZyBP1JsS3rGb+eiuMAiiKuNSsWC+/Lt7XQXSuJ3YVEWYwYNtncuiaxZ9LmDS/4SLOxq/M5BQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2253,9 +2284,9 @@
 			}
 		},
 		"node_modules/@j178/prek-win32-arm64-msvc": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-win32-arm64-msvc/-/prek-win32-arm64-msvc-0.3.11.tgz",
-			"integrity": "sha512-BvEYe57E8+tdDLczjYR3q4Ne67bU2uwoAVtK5za2WnpqOtCUExdBNZzjOHXUO8XGbUCuLKacL011ReJimW69Jw==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-win32-arm64-msvc/-/prek-win32-arm64-msvc-0.3.13.tgz",
+			"integrity": "sha512-y01wCK7u4eH/9ETmiYAOLlOcr38oA453VXNA+PuWcbGCAKeGvDIpsYs4x2uKfAibULWbrveCrRg0tTLjZ5YeBQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2270,9 +2301,9 @@
 			}
 		},
 		"node_modules/@j178/prek-win32-ia32-msvc": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-win32-ia32-msvc/-/prek-win32-ia32-msvc-0.3.11.tgz",
-			"integrity": "sha512-CliNOKv6/Ktuzp4XGmDAcnEQQmDeV1CsoPMwGDBC/kAd9mByUO4ag591lQFWMMfvHlwQc/mJhXU+2D9QK/riRg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-win32-ia32-msvc/-/prek-win32-ia32-msvc-0.3.13.tgz",
+			"integrity": "sha512-nz/6XFNsJ2b/SnVpn/0PAPxBqEQJZGDCDXVt1UyHsGyPFzmxrvHjRIksrbWxXfIhkBv8iyEIlJGk7q8+gG2cZA==",
 			"cpu": [
 				"ia32"
 			],
@@ -2287,9 +2318,9 @@
 			}
 		},
 		"node_modules/@j178/prek-win32-x64-msvc": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@j178/prek-win32-x64-msvc/-/prek-win32-x64-msvc-0.3.11.tgz",
-			"integrity": "sha512-4uih+Xg2Zj2iR8nfAn0hqJXlaztG7UQrZ/CzcUfIrVNd+sIvgvo+KcpPC6rZflZ15ipwm3zmQhU0l+seh4u6Eg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@j178/prek-win32-x64-msvc/-/prek-win32-x64-msvc-0.3.13.tgz",
+			"integrity": "sha512-891Ly7bFbbOi9VQfwpb146BiEhDC+oqofXaZ/Hd10Xiv/wYjRzzym2rjThlRvrRv8rj0exeN557YwyRsk5RPCw==",
 			"cpu": [
 				"x64"
 			],
@@ -2689,9 +2720,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.127.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-			"integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+			"integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2763,9 +2794,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2780,9 +2811,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2797,9 +2828,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
 			"cpu": [
 				"x64"
 			],
@@ -2814,9 +2845,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
 			"cpu": [
 				"x64"
 			],
@@ -2831,9 +2862,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-			"integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+			"integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
 			"cpu": [
 				"arm"
 			],
@@ -2848,9 +2879,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2865,9 +2896,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
 			"cpu": [
 				"arm64"
 			],
@@ -2882,9 +2913,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2899,9 +2930,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
 			"cpu": [
 				"s390x"
 			],
@@ -2916,9 +2947,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-			"integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
 			"cpu": [
 				"x64"
 			],
@@ -2933,9 +2964,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
 			"cpu": [
 				"x64"
 			],
@@ -2950,9 +2981,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-			"integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
 			"cpu": [
 				"arm64"
 			],
@@ -2967,9 +2998,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-			"integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+			"integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2986,9 +3017,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3003,9 +3034,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-			"integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
 			"cpu": [
 				"x64"
 			],
@@ -3020,9 +3051,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-			"integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+			"integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3630,9 +3661,9 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
-			"integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+			"integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/service-error-classification": "^4.3.1",
@@ -3736,9 +3767,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -3765,9 +3796,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3778,9 +3809,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "25.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+			"integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3809,6 +3840,7 @@
 			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.5",
@@ -3833,13 +3865,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@vitest/coverage-v8/node_modules/std-env": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.5",
@@ -3999,6 +4024,21 @@
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -4069,6 +4109,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4137,6 +4186,18 @@
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
 			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
 			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/buffer": {
 			"version": "5.7.1",
@@ -4315,21 +4376,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cli-highlight/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/cli-highlight/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4357,26 +4403,6 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/cli-highlight/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"license": "MIT"
-		},
-		"node_modules/cli-highlight/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/cli-highlight/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4387,23 +4413,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/cli-highlight/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/cli-highlight/node_modules/yargs": {
@@ -4458,44 +4467,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cliui/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/cliui/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/cliui/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4507,24 +4478,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/color-convert": {
@@ -4666,6 +4619,16 @@
 				"typescript": ">=5"
 			}
 		},
+		"node_modules/cosmiconfig-typescript-loader/node_modules/jiti": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -4737,35 +4700,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/decompress-tar/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-tar/node_modules/tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/decompress-tarbz2": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
@@ -4793,16 +4727,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/decompress-tarbz2/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/decompress-targz": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
@@ -4826,16 +4750,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-targz/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decompress-unzip": {
@@ -5014,6 +4928,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5034,9 +4954,9 @@
 			}
 		},
 		"node_modules/envalid": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/envalid/-/envalid-8.1.0.tgz",
-			"integrity": "sha512-OT6+qVhKVyCidaGoXflb2iK1tC8pd0OV2Q+v9n33wNhUJ+lus+rJobUj4vJaQBPxPZ0vYrPGuxdrenyCAIJcow==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/envalid/-/envalid-8.1.1.tgz",
+			"integrity": "sha512-vOUfHxAFFvkBjbVQbBfgnCO9d3GcNfMMTtVfgqSU2rQGMFEVqWy9GBuoSfHnwGu7EqR0/GeukQcL3KjFBaga9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5095,6 +5015,17 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-toolkit": {
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+			"integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
 		"node_modules/es6-error": {
 			"version": "4.1.1",
@@ -5288,9 +5219,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5305,9 +5236,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+			"integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
 			"funding": [
 				{
 					"type": "github",
@@ -5809,9 +5740,9 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^11.1.0"
@@ -5938,9 +5869,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-			"integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -6003,6 +5934,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-typed-array": {
@@ -6068,10 +6009,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-			"dev": true,
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
@@ -6168,9 +6108,9 @@
 			}
 		},
 		"node_modules/koffi": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
-			"integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+			"integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -6446,48 +6386,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.kebabcase": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-			"integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.snakecase": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.startcase": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-			"integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.upperfirst": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-			"integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/long": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -6495,9 +6393,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -6629,27 +6527,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/minimatch/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -6687,9 +6564,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7025,9 +6902,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
 			"dev": true,
 			"funding": [
 				{
@@ -7079,12 +6956,6 @@
 			"engines": {
 				"node": ">= 4"
 			}
-		},
-		"node_modules/proper-lockfile/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"license": "ISC"
 		},
 		"node_modules/protobufjs": {
 			"version": "7.5.6",
@@ -7243,14 +7114,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.17",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-			"integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+			"integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.127.0",
-				"@rolldown/pluginutils": "1.0.0-rc.17"
+				"@oxc-project/types": "=0.128.0",
+				"@rolldown/pluginutils": "1.0.0-rc.18"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -7259,21 +7130,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -7311,9 +7182,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7389,6 +7260,12 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -7461,6 +7338,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -7478,13 +7362,48 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -7504,9 +7423,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -7516,9 +7435,9 @@
 			"license": "MIT"
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -7541,6 +7460,25 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^1.0.0",
+				"buffer-alloc": "^1.2.0",
+				"end-of-stream": "^1.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.1",
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/thenify": {
@@ -7579,9 +7517,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7710,9 +7648,9 @@
 			}
 		},
 		"node_modules/typebox": {
-			"version": "1.1.34",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.34.tgz",
-			"integrity": "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ==",
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
 			"license": "MIT"
 		},
 		"node_modules/typed-array-buffer": {
@@ -7810,17 +7748,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-			"integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+			"version": "8.0.11",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+			"integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.10",
-				"rolldown": "1.0.0-rc.17",
+				"postcss": "^8.5.14",
+				"rolldown": "1.0.0-rc.18",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -7837,7 +7775,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -7979,13 +7917,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/std-env": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -8029,6 +7960,44 @@
 			},
 			"bin": {
 				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -8081,9 +8050,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -8124,51 +8093,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/yargs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/yauzl": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -8180,9 +8104,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"peer": true,
 			"funding": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"dependencies": {
 		"@actions/core": "^3.0.1",
 		"@actions/github": "^9.1.1",
-		"@mariozechner/pi-coding-agent": "^0.70.6",
+		"@earendil-works/pi-coding-agent": "^0.74.0",
 		"tsx": "^4.21.0"
 	},
 	"devDependencies": {

--- a/src/agent-session.ts
+++ b/src/agent-session.ts
@@ -6,7 +6,7 @@ import {
 	type ModelRegistry,
 	SessionManager,
 	SettingsManager,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "./agent.js";
 
 type CreateAgentSessionResult = Awaited<ReturnType<typeof createAgentSession>>;

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -8,7 +8,7 @@ import {
 import type { AgentResult } from "./types.js";
 
 // Mock the pi-coding-agent SDK
-vi.mock("@mariozechner/pi-coding-agent", () => {
+vi.mock("@earendil-works/pi-coding-agent", () => {
 	const mockSession = {
 		subscribe: vi.fn(),
 		prompt: vi.fn(),
@@ -52,7 +52,7 @@ import {
 	createAgentSession,
 	DefaultResourceLoader,
 	ModelRegistry,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 
 const mockAuthStorageInMemory = AuthStorage.inMemory as Mock;
 const mockCreateAgentSession = createAgentSession as Mock;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { type AgentLogger, createSessionEventHandler } from "./agent-events.js";
 import { createConfiguredAgentSession } from "./agent-session.js";
 import type { PIContext } from "./context.js";

--- a/src/custom-provider.ts
+++ b/src/custom-provider.ts
@@ -1,4 +1,4 @@
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { DEFAULTS } from "./defaults.js";
 import {
 	getInputOrDefault,


### PR DESCRIPTION
Two fixes we've been carrying in our fork (`Gravity-Rail/pi-action`) that we'd like to upstream:

### 1. Switch the agent SDK dep to its renamed successor

`@mariozechner/pi-coding-agent` was deprecated at 0.73.x; the package was renamed to `@earendil-works/pi-coding-agent` at 0.74.0, which is where the newer xAI grok models (e.g. `grok-4.3`) are registered. Without this, `pi --provider xai --model grok-4.3` errors with `Model not found: xai/grok-4.3` even though the model is real on x.ai's API.

The exported API surface is unchanged — `AuthStorage`, `ModelRegistry`, `createAgentSession`, `DefaultResourceLoader`, `getAgentDir`, `SessionManager`, `SettingsManager` all still exported with the same shapes. `tsc --noEmit` passes and the full 189-test suite passes.

### 2. Regenerate `package-lock.json` with `--include=optional`

The current lock was generated on macOS ARM64 and pruned Linux-specific transitive deps (`@emnapi/core`, `@emnapi/runtime`, …). On GitHub-hosted Linux runners that surfaces as:

```
npm error Missing: @emnapi/core@1.10.0 from lock file
npm error Missing: @emnapi/runtime@1.10.0 from lock file
```

`npm install --include=optional` captures all platform variants (`linux-arm64`, `linux-x64`, `darwin-arm64`, `darwin-x64`, `win32-*`) so `npm ci` is stable regardless of host. Same reason `actions/setup-node` and many other JS-actions repos use this flag.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full test suite passes (189 tests)
- [x] Action has been running this exact tree (`69e4327747`) in production CI for ~3 days against issue/PR triggers in `Gravity-Rail/gravity-team` with no regressions

Happy to split into two PRs if you'd prefer — I bundled them because the lockfile regen is the natural follow-up to the dep rename.

Thanks! — Dan / Gravity Rail